### PR TITLE
Simplify ControlWidget

### DIFF
--- a/application/src/control_widget.cpp
+++ b/application/src/control_widget.cpp
@@ -1,7 +1,5 @@
 #include "control_widget.h"
 
-#include <stdexcept>
-
 #include <imgui.h>
 
 ControlWidget::ControlWidget(
@@ -14,50 +12,28 @@ ControlWidget::ControlWidget(
 
 void ControlWidget::update() {
     ImGui::Begin("NES control");
-    try {
-        if (ImGui::Button("Step")) {
-            *step_running_ = 1;
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Step 10")) {
-            *step_running_ = 10;
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Step 100")) {
-            *step_running_ = 100;
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Step 1000")) {
-            *step_running_ = 1000;
-        }
 
-        ImGui::SameLine();
-        if (!*running_) {
-            if (ImGui::Button("Run")) {
-                *running_ = true;
-            }
-        } else {
-            if (ImGui::Button("Stop")) {
-                *running_ = false;
-            }
-        }
+    if (ImGui::Button("Step")) { *step_running_ = 1; }
+    ImGui::SameLine();
+    if (ImGui::Button("Step 10")) { *step_running_ = 10; }
+    ImGui::SameLine();
+    if (ImGui::Button("Step 100")) { *step_running_ = 100; }
+    ImGui::SameLine();
+    if (ImGui::Button("Step 1000")) { *step_running_ = 1000; }
+    ImGui::SameLine();
 
-        if (ImGui::Button("Step 10000")) {
-            *step_running_ = 10000;
+    if (!*running_) {
+        if (ImGui::Button("Run")) {
+            *running_ = true;
         }
-        ImGui::SameLine();
-        if (ImGui::Button("Step 100000")) {
-            *step_running_ = 100000;
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Reset")) {
-            nes_->reset();
-        }
-
-    } catch (const std::logic_error &e) {
-        last_exception_ = e.what();
+    } else if (ImGui::Button("Stop")) {
         *running_ = false;
     }
-    ImGui::Text(last_exception_.c_str());
+
+    if (ImGui::Button("Step 10000")) { *step_running_ = 10000; }
+    ImGui::SameLine();
+    if (ImGui::Button("Step 100000")) { *step_running_ = 100000; }
+    ImGui::SameLine();
+    if (ImGui::Button("Reset")) { nes_->reset(); }
     ImGui::End();
 }

--- a/application/src/control_widget.h
+++ b/application/src/control_widget.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string>
-
 #include <nes/nes.h>
 
 class ControlWidget {
@@ -13,5 +11,4 @@ private:
     n_e_s::nes::Nes *const nes_;
     bool *running_;
     int *step_running_;
-    std::string last_exception_{};
 };


### PR DESCRIPTION
It no longer calls into functions in n_e_s that can throw exceptions, so
all that could be removed. The if-cases also felt short/simple enough
that placing them on a single line increased the readability.