### PR TITLE
Fix bug in event handling

### DIFF
--- a/application/src/main.cpp
+++ b/application/src/main.cpp
@@ -71,14 +71,10 @@ int main(int argc, char **argv) {
         window.clear();
         deltaClock.restart();
 
-            sf::Event event;
-            while (window.pollEvent(event)) {
-                ImGui::SFML::ProcessEvent(event);
-    
-            sf::Event event;
-            while (window.pollEvent(event)) {
-                ImGui::SFML::ProcessEvent(event);
-                switch (event.type) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            ImGui::SFML::ProcessEvent(event);
+            switch (event.type) {
                 case sf::Event::Closed: {
                     window.close();
                     break;
@@ -93,7 +89,6 @@ int main(int argc, char **argv) {
                 }
                 default:
                     break;
-                }
             }
         }
 


### PR DESCRIPTION
Duplicated event polling clears all events before the loop that actually handles them reads them.